### PR TITLE
Don't use mypy cache in nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -35,8 +35,8 @@ nox.options.sessions = ["lock", "format", "lint", "test"]
 # All linters and formatters are run with `uv run --active`
 LINTERS: list[tuple[str, ...]] = [
     ("flake8", "--show-source", LINT_PATH, TESTS_PATH),
-    ("mypy", "--pretty", "--package", MODULE_NAME),
-    ("mypy", "--pretty", TESTS_PATH),
+    ("mypy", "--no-incremental", "--pretty", "--package", MODULE_NAME),
+    ("mypy", "--no-incremental", "--pretty", TESTS_PATH),
 ]
 FORMATTERS: list[tuple[str, ...]] = [
     (


### PR DESCRIPTION
Getting some errors with mypy but can't duplicate yet. Cleaning all caches resolves the issue.

```py
Traceback (most recent call last):
  File "/home/preocts/twitch-alerts/.venv/bin/mypy", line 10, in <module>
    sys.exit(console_entry())
             ~~~~~~~~~~~~~^^
  File "/home/preocts/twitch-alerts/.venv/lib/python3.14/site-packages/mypy/__main__.py", line 15, in console_entry
    main()
    ~~~~^^
  File "mypy/main.py", line 127, in main
  File "mypy/main.py", line 211, in run_build
  File "mypy/build.py", line 191, in build
  File "mypy/build.py", line 267, in _build
  File "mypy/build.py", line 2939, in dispatch
  File "mypy/build.py", line 3330, in process_graph
  File "mypy/build.py", line 3408, in process_fresh_modules
  File "mypy/build.py", line 2096, in load_tree
  File "mypy/nodes.py", line 379, in deserialize
  File "mypy/nodes.py", line 4147, in deserialize
  File "mypy/nodes.py", line 4087, in deserialize
  File "mypy/nodes.py", line 240, in deserialize
  File "mypy/nodes.py", line 1142, in deserialize
KeyError: 'setter_type'
nox > Command uv run --frozen --quiet --active mypy --pretty ./tests failed with exit code 1
```