### PR TITLE
Handle ConnectionError exceptions

### DIFF
--- a/src/twitch_alerts/_twitch_alerts.py
+++ b/src/twitch_alerts/_twitch_alerts.py
@@ -110,7 +110,13 @@ def _get_channel(channel_name: str, auth: Auth) -> Channel:
     url = "https://api.twitch.tv/helix/streams"
     params = {"user_login": channel_name}
 
-    response = requests.get(url, params=params, timeout=3, headers=auth.headers)
+    try:
+        response = requests.get(url, params=params, timeout=3, headers=auth.headers)
+
+    except requests.ConnectionError as err:
+        msg = f"Connection error, skipping check on {channel_name}: {err}"
+        logger.error("%s", msg)
+        raise ValueError(msg)
 
     if not response.ok:
         msg = f"Failed to fetch '{channel_name}' with error: {response.text}"


### PR DESCRIPTION
Treating the exception the same as a no data action. These happen on random occation. Some retry logic might be needed but only if this doesn't fix the issue.

Trackback of the issue:

```
Traceback (most recent call last):
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connection.py", line 198, in _new_conn
    sock = connection.create_connection(
        (self._dns_host, self.port),
    ...<2 lines>...
        socket_options=self.socket_options,
    )
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/util/connection.py", line 60, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
               ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/socket.py", line 977, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -3] Temporary failure in name resolution

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 488, in _make_request
    raise new_e
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 464, in _make_request
    self._validate_conn(conn)
    ~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 1093, in _validate_conn
    conn.connect()
    ~~~~~~~~~~~~^^
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connection.py", line 753, in connect
    self.sock = sock = self._new_conn()
                       ~~~~~~~~~~~~~~^^
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connection.py", line 205, in _new_conn
    raise NameResolutionError(self.host, self, e) from e
urllib3.exceptions.NameResolutionError: <urllib3.connection.HTTPSConnection object at 0x71373c32f610>: Failed to resolve 'api.twitch.tv' ([Errno -3] Temporary failure in name resolution)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/requests/adapters.py", line 644, in send
    resp = conn.urlopen(
        method=request.method,
    ...<9 lines>...
        chunked=chunked,
    )
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
        method, url, error=new_e, _pool=self, _stacktrace=sys.exc_info()[2]
    )
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/urllib3/util/retry.py", line 519, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='api.twitch.tv', port=443): Max retries exceeded with url: /helix/streams?user_login=teknokat222 (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x71373c32f610>: Failed to resolve 'api.twitch.tv' ([Errno -3] Temporary failure in name resolution)"))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/preocts/twitch-alerts-prod/.venv/bin/twitch-alerts-scan", line 10, in <module>
    sys.exit(run())
             ~~~^^
  File "/home/preocts/twitch-alerts-prod/src/twitch_alerts/__main__.py", line 46, in run
    _twitch_alerts.run()
    ~~~~~~~~~~~~~~~~~~^^
  File "/home/preocts/twitch-alerts-prod/src/twitch_alerts/_twitch_alerts.py", line 307, in run
    new_channels = isolate_who_went_live(
        auth=auth,
        state_file=STATE_FILE,
        channels=sorted(config.twitch_channel_names),
    )
  File "/home/preocts/twitch-alerts-prod/src/twitch_alerts/_twitch_alerts.py", line 186, in isolate_who_went_live
    channel = _get_channel(channel_name, auth)
  File "/home/preocts/twitch-alerts-prod/src/twitch_alerts/_twitch_alerts.py", line 113, in _get_channel
    response = requests.get(url, params=params, timeout=3, headers=auth.headers)
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/preocts/twitch-alerts-prod/.venv/lib/python3.13/site-packages/requests/adapters.py", line 677, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.twitch.tv', port=443): Max retries exceeded with url: /helix/streams?user_login=teknokat222 (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x71373c32f610>: Failed to resolve 'api.twitch.tv' ([Errno -3] Temporary failure in name resolution)"))
```

Egg